### PR TITLE
Changed Configuration to avoid manual start of the Redis Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,4 @@ Run `rails db:migrate` to create the database and the migrations.
 Run `rails db:seed` to seed the database.  
 Run `rails s` to start the rails server (it will run on on PORT 3000). 
 
-In another terminal window, run `redis-server`.  
 Open [localhost:3000](http://localhost:3000) in your browser.

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,7 +1,6 @@
 development:
-  adapter: redis
-  url: redis://localhost:6379/1
-
+  adapter: async
+  
 test:
   adapter: test
 


### PR DESCRIPTION
Update to Redis server configuration settings to allow web sockets to run without the need for a manual start of the Redis server. 